### PR TITLE
Fix WebSocket message loop termination

### DIFF
--- a/shared/shared/connection.py
+++ b/shared/shared/connection.py
@@ -124,9 +124,10 @@ class ConnectionManager:
         Async task that processes queued messages and broadcasts them to clients.
         
         Continuously checks the message queue and broadcasts valid messages
-        to all connected WebSocket clients for the relevant job ID.
+        to all connected WebSocket clients for the relevant job ID. The loop
+        exits when ``should_stop`` is set to ``True``.
         """
-        while True:
+        while not self.should_stop:
             try:
                 # Check queue in a non-blocking way
                 while not self.message_queue.empty():


### PR DESCRIPTION
## Summary
- stop background `_process_messages` task when `ConnectionManager.cleanup()` is called

## Testing
- `ruff check shared/shared/connection.py`