### PR TITLE
Improve startup and JSON parsing

### DIFF
--- a/shared/shared/llmmanager.py
+++ b/shared/shared/llmmanager.py
@@ -425,6 +425,9 @@ class LLMManager:
 
     def _clean_and_parse_json(self, content: str) -> dict:
         """Clean and parse JSON response from Ollama."""
+        # Explicitly import ujson here to avoid any local scope issues that could
+        # lead to "local variable 'json' referenced before assignment" errors
+        import ujson as json
         # Remove any leading/trailing whitespace
         content = content.strip()
         


### PR DESCRIPTION
## Summary
- adjust main TTS service so Dia loads at startup
- explicitly import `ujson` inside the JSON cleaning helper to avoid UnboundLocalError

## Testing
- `python -m py_compile shared/shared/llmmanager.py services/TTSService/main.py`
- `ruff check shared/shared/llmmanager.py` *(fails: E722, F841)*
