### PR TITLE
Handle missing ujson module and log truncation

### DIFF
--- a/frontend/shared/shared/connection.py
+++ b/frontend/shared/shared/connection.py
@@ -16,7 +16,10 @@
 from fastapi import WebSocket, WebSocketDisconnect
 from typing import Dict, Set
 import redis
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import logging
 import time
 import asyncio

--- a/frontend/shared/shared/job.py
+++ b/frontend/shared/shared/job.py
@@ -17,7 +17,10 @@ from shared.api_types import ServiceType
 from shared.otel import OpenTelemetryInstrumentation
 import redis
 import time
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import threading
 
 

--- a/frontend/shared/shared/llmmanager.py
+++ b/frontend/shared/shared/llmmanager.py
@@ -16,7 +16,10 @@
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
 from typing import List, Dict, Any, Optional, Union
 import logging
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 from shared.otel import OpenTelemetryInstrumentation
 from opentelemetry.trace.status import StatusCode
 from pathlib import Path

--- a/frontend/shared/shared/storage.py
+++ b/frontend/shared/shared/storage.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import io
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import base64
 from minio import Minio
 from minio.error import S3Error

--- a/services/APIService/main.py
+++ b/services/APIService/main.py
@@ -48,7 +48,10 @@ from pydantic import ValidationError
 import redis
 import requests
 import httpx
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import uuid
 import os
 import logging

--- a/services/AgentService/main.py
+++ b/services/AgentService/main.py
@@ -32,7 +32,10 @@ from shared.llmmanager import LLMManager
 from shared.job import JobStatusManager
 from shared.otel import OpenTelemetryInstrumentation, OpenTelemetryConfig
 from opentelemetry.trace.status import StatusCode
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import os
 import logging
 from shared.prompt_tracker import PromptTracker

--- a/services/AgentService/monologue_flow.py
+++ b/services/AgentService/monologue_flow.py
@@ -11,7 +11,10 @@ from shared.pdf_types import PDFMetadata  # PDF document metadata and content
 from shared.llmmanager import LLMManager  # LLM interaction management
 from shared.job import JobStatusManager  # Background job status tracking
 from typing import List, Dict  # Type hints
-import ujson as json  # Fast JSON processing
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import logging  # Logging utilities
 from shared.prompt_tracker import PromptTracker  # Tracks prompts sent to LLM
 from monologue_prompts import FinancialSummaryPrompts  # Prompt templates

--- a/services/AgentService/podcast_flow.py
+++ b/services/AgentService/podcast_flow.py
@@ -11,7 +11,10 @@ from shared.api_types import JobStatus, TranscriptionRequest
 from shared.llmmanager import LLMManager
 from shared.job import JobStatusManager
 from typing import List, Dict, Any, Coroutine
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import logging
 from shared.prompt_tracker import PromptTracker
 from podcast_prompts import PodcastPrompts

--- a/services/AgentService/test_api.py
+++ b/services/AgentService/test_api.py
@@ -6,7 +6,10 @@ verifying the full workflow from request submission to job completion.
 """
 
 import requests
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import os
 import time
 from shared.api_types import TranscriptionRequest

--- a/services/PDFService/PDFModelService/test_pdf_api.py
+++ b/services/PDFService/PDFModelService/test_pdf_api.py
@@ -1,6 +1,9 @@
 import requests
 import sys
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import time
 from pathlib import Path
 

--- a/services/PDFService/main.py
+++ b/services/PDFService/main.py
@@ -7,7 +7,10 @@ import tempfile
 import os
 import logging
 import asyncio
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 from typing import List
 from shared.pdf_types import PDFConversionResult, ConversionStatus, PDFMetadata
 from shared.api_types import ServiceType, JobStatus, StatusResponse

--- a/services/TTSService/test_api.py
+++ b/services/TTSService/test_api.py
@@ -1,5 +1,8 @@
 import requests
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import os
 import time
 from fastapi import HTTPException

--- a/shared/shared/connection.py
+++ b/shared/shared/connection.py
@@ -1,7 +1,10 @@
 from fastapi import WebSocket, WebSocketDisconnect
 from typing import Dict, Set
 import redis
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import logging
 import time
 import asyncio

--- a/shared/shared/job.py
+++ b/shared/shared/job.py
@@ -2,7 +2,10 @@ from shared.api_types import ServiceType
 from shared.otel import OpenTelemetryInstrumentation
 import redis
 import time
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import threading
 
 

--- a/shared/shared/llmmanager.py
+++ b/shared/shared/llmmanager.py
@@ -1,6 +1,9 @@
 from typing import List, Dict, Any, Optional, Union
 import logging
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 from shared.otel import OpenTelemetryInstrumentation
 from opentelemetry.trace.status import StatusCode
 from pathlib import Path
@@ -144,7 +147,10 @@ class LLMManager:
         # Truncate prompt if too long (approximate token counting - 1 token ≈ 4 characters)
         max_chars = 20000  # ~5000 tokens, leaving room for response
         if len(full_prompt) > max_chars:
-            logger.warning(f"Prompt too long ({len(full_prompt)} chars), truncating to {max_chars} chars")
+            removed_chars = len(full_prompt) - max_chars
+            logger.warning(
+                f"Prompt too long ({len(full_prompt)} chars), truncating to {max_chars} chars (removing {removed_chars} chars)"
+            )
             # Try to keep the end of the prompt which is usually most important
             full_prompt = "..." + full_prompt[-max_chars:]
         

--- a/shared/shared/storage.py
+++ b/shared/shared/storage.py
@@ -1,5 +1,8 @@
 import io
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 import base64
 from minio import Minio
 from minio.error import S3Error

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -7,7 +7,10 @@ and prompt history retrieval endpoints of the PDF-to-Podcast API service.
 import requests
 import os
 from datetime import datetime
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 
 # Set your job_id here
 JOB_ID = "1730947535"

--- a/tests/test_invalid_filetype.py
+++ b/tests/test_invalid_filetype.py
@@ -7,7 +7,10 @@ invalid file types and malformed transcription parameters.
 import os
 import requests
 from requests import Response
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 from datetime import datetime
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -5,7 +5,10 @@ from the PDF-to-Podcast API service, including their metadata and transcription 
 """
 
 import requests
-import ujson as json
+try:
+    import ujson as json  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import json  # type: ignore
 from datetime import datetime
 
 


### PR DESCRIPTION
## Summary
- fall back to the builtin json module if ujson isn't available
- report the number of removed characters when prompts are truncated

## Testing
- `python -m py_compile services/TTSService/main.py shared/shared/llmmanager.py`
- `ruff check shared/shared/job.py shared/shared/llmmanager.py`
- `pytest -q` *(fails: ModuleNotFoundError for requests & minio)*