### PR TITLE
Enhance TTS batching and dialogue controls

### DIFF
--- a/frontend/shared/shared/api_types.py
+++ b/frontend/shared/shared/api_types.py
@@ -76,6 +76,17 @@ class TranscriptionParams(BaseModel):
         False,
         description="If True, creates a VDB task when running NV-Ingest allowing for retrieval abilities",
     )
+    tts_chunk_chars: int = Field(
+        4000,
+        description="Maximum characters per TTS batch for pacing control",
+        gt=100,
+        le=10000,
+    )
+
+    use_emotion_tags: bool = Field(
+        True,
+        description="Allow emotion tags like (laughs) in the generated dialogue",
+    )
 
     @model_validator(mode="after")
     def validate_monologue_settings(self) -> "TranscriptionParams":

--- a/frontend/utils/email_demo.py
+++ b/frontend/utils/email_demo.py
@@ -286,7 +286,7 @@ def test_api(
     transcription_params = {
         "name": "ishan-test",
         "duration": 2,
-        "speaker_1_name": "Bob",
+        "speaker_1_name": "Chris",
         "voice_mapping": voice_mapping,
         "guide": None,
         "monologue": monologue,
@@ -295,7 +295,7 @@ def test_api(
     }
 
     if not monologue:
-        transcription_params["speaker_2_name"] = "Kate"
+        transcription_params["speaker_2_name"] = "Andy"
 
     print(
         f"\n[{datetime.now().strftime('%H:%M:%S')}] Submitting PDFs for processing..."

--- a/services/APIService/main.py
+++ b/services/APIService/main.py
@@ -314,6 +314,7 @@ def process_pdf_task(
                                         "dialogue": agent_result["dialogue"],
                                         "job_id": job_id,
                                         "voice_mapping": transcription_params.voice_mapping,  # Forward the voice mapping
+                                        "max_chars": transcription_params.tts_chunk_chars,
                                     },
                                 )
                                 current_service = ServiceType.TTS

--- a/services/AgentService/podcast_flow.py
+++ b/services/AgentService/podcast_flow.py
@@ -390,6 +390,7 @@ async def podcast_generate_dialogue_segment(
         descriptions=topics_text,
         speaker_1_name=request.speaker_1_name,
         speaker_2_name=request.speaker_2_name,
+        use_emotion_tags=request.use_emotion_tags,
     )
 
     # Query LLM for dialogue

--- a/services/AgentService/podcast_prompts.py
+++ b/services/AgentService/podcast_prompts.py
@@ -211,6 +211,12 @@ There are two speakers:
     - Ensure the guest's responses are substantiated by the input text, avoiding unsupported claims.
     - Avoid long monologues; break information into interactive exchanges.
     - Use dialogue tags to express emotions (e.g., "he said excitedly", "she replied thoughtfully") to guide voice synthesis.
+    {% if use_emotion_tags %}
+    - You may insert contextual emotion cues like (laughs) or (sighs) when it feels natural.
+    {% else %}
+    - Do not insert any emotion cues like (laughs) or (sighs).
+    {% endif %}
+    - Avoid exclamation marks (!) unless absolutely necessary.
     - Strive for authenticity. Include:
         - Moments of genuine curiosity or surprise from the host.
         - Instances where the guest may pause to articulate complex ideas.

--- a/services/TTSService/main.py
+++ b/services/TTSService/main.py
@@ -4,9 +4,7 @@ import sys
 import logging
 from fastapi import FastAPI, BackgroundTasks, HTTPException, Response
 from pydantic import BaseModel
-from enum import Enum
-from datetime import datetime
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional
 from shared.otel import OpenTelemetryInstrumentation, OpenTelemetryConfig
 from shared.job import JobStatusManager
 from shared.api_types import ServiceType, JobStatus
@@ -35,11 +33,15 @@ class DialogueEntry(BaseModel):
     speaker: str
     voice_id: Optional[str] = None
 
+DEFAULT_MAX_CHARS = int(os.getenv("TTS_MAX_CHARS", "4000"))
+
+
 class TTSRequest(BaseModel):
     dialogue: List[DialogueEntry]
     job_id: str
     scratchpad: Optional[str] = ""
     voice_mapping: Optional[Dict[str, str]] = {}
+    max_chars: int = DEFAULT_MAX_CHARS
 
 # Initialize FastAPI app
 app = FastAPI(title="Dia TTS Service")
@@ -193,7 +195,7 @@ class DiaTTS:
             logger.error(traceback.format_exc())
             raise RuntimeError(f"Failed to generate speech: {e}")
 
-def chunk_dialogue(dialogue: List[DialogueEntry], max_chars: int = 4000) -> List[List[DialogueEntry]]:
+def chunk_dialogue(dialogue: List[DialogueEntry], max_chars: int = DEFAULT_MAX_CHARS) -> List[List[DialogueEntry]]:
     """Split dialogue into chunks under a character limit."""
     chunks: List[List[DialogueEntry]] = []
     current: List[DialogueEntry] = []
@@ -255,7 +257,7 @@ async def process_job(job_id: str, tts_request: TTSRequest):
             set_speaker_seeds(job_id, seeds)
 
         # Process dialogue in chunks
-        chunks = chunk_dialogue(tts_request.dialogue)
+        chunks = chunk_dialogue(tts_request.dialogue, max_chars=tts_request.max_chars)
         audio_chunks: List[bytes] = []
 
         logger.info("Using local Dia for TTS generation")

--- a/services/TTSService/sample.json
+++ b/services/TTSService/sample.json
@@ -2,11 +2,11 @@
     "scratchpad": "",
     "dialogue": [
       {
-        "text": "Welcome to our discussion on attention models in natural language processing. I'm Kate, and I'm excited to be joined today by Bob. Hi, Bob.",
+        "text": "Welcome to our discussion on attention models in natural language processing. I'm Chris, and I'm excited to be joined today by Andy. Hi, Andy.",
         "speaker": "speaker-1"
       },
       {
-        "text": "Hi, Kate. It's great to be here.",
+        "text": "Hi, Chris. It's great to be here.",
         "speaker": "speaker-2"
       },
       {
@@ -178,11 +178,11 @@
         "speaker": "speaker-2"
       },
       {
-        "text": "Okay, well, I think that's all the time we have for today. Thanks for joining me, Bob.",
+        "text": "Okay, well, I think that's all the time we have for today. Thanks for joining me, Andy.",
         "speaker": "speaker-1"
       },
       {
-        "text": "Thanks, Kate. It was a pleasure.",
+        "text": "Thanks, Chris. It was a pleasure.",
         "speaker": "speaker-2"
       },
       {

--- a/shared/shared/api_types.py
+++ b/shared/shared/api_types.py
@@ -66,6 +66,17 @@ class TranscriptionParams(BaseModel):
         False,
         description="If True, creates a VDB task when running NV-Ingest allowing for retrieval abilities",
     )
+    tts_chunk_chars: int = Field(
+        4000,
+        description="Maximum characters per TTS batch for pacing control",
+        gt=100,
+        le=10000,
+    )
+
+    use_emotion_tags: bool = Field(
+        True,
+        description="Allow emotion tags like (laughs) in the generated dialogue",
+    )
 
     @model_validator(mode="after")
     def validate_monologue_settings(self) -> "TranscriptionParams":

--- a/tests/test.py
+++ b/tests/test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 TEST_USER_ID = "test-userid"
 
 # Add at top of file after imports
-SPEAKER_NAMES = ["Bob", "Kate", "Alex", "Sarah", "Mike"]
+SPEAKER_NAMES = ["Chris", "Andy", "Alex", "Taylor"]
 
 
 class StatusMonitor:

--- a/variables.env
+++ b/variables.env
@@ -6,3 +6,4 @@ MAX_CONCURRENT_REQUESTS=1
 API_SERVICE_URL=http://pdf-to-podcast-api-service-1:8002
 AI_WORKBENCH_FLAG=true
 SENDER_EMAIL=To use email, you must also add SENDER_EMAIL_PASSWORD as a Secret!
+TTS_MAX_CHARS=4000


### PR DESCRIPTION
## Summary
- allow configuring TTS chunk size via API and environment variable
- add optional emotion tags in prompts and avoid exclamation marks
- pass `use_emotion_tags` through AgentService
- update demo names to gender‑neutral Chris and Andy
- document new env var `TTS_MAX_CHARS`

## Testing
- `ruff check . --fix`
- `pytest -q` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839d10a7184832aa1c416f837bfa8ca